### PR TITLE
Use MarkPlugin to render color nodes too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import TableToolbarMenu from './components/TableToolbarMenu'
 import { MarkPlugin, MarkButton } from './plugins/Mark'
 import { BlockPlugin, BlockButton } from './plugins/Block'
 import { VoidPlugin, VoidButton } from './plugins/Void'
-import { ColorPlugin, ColorButton } from './plugins/Color'
+import { ColorButton } from './plugins/Color'
 import { PlainButton } from './plugins/Plain'
 import { TablePlugin, TableButton } from './plugins/Table'
 
@@ -31,7 +31,6 @@ const plugins = [
   VoidPlugin({ type: 'underbar', tag: 'span', attributes: { className: 'underbar' } }),
   VoidPlugin({ type: 'underbar_l', tag: 'span', attributes: { className: 'underbar_l' } }),
   VoidPlugin({ type: 'underbar_xl', tag: 'span', attributes: { className: 'underbar_xl' } }),
-  ColorPlugin({ type: 'color' }),
   TablePlugin({ type: 'arrow' }),
   EditTablePlugin,
 ]
@@ -175,13 +174,13 @@ class TopicEditor extends React.Component {
             <ColorButton color="blue" icon="font" title="Blue" {...sharedProps} />
           </div>
           <div className="menu">
-            <ColorButton color="male" icon="mars" title="Male" {...sharedProps} />
-            <ColorButton color="female" icon="venus" title="Female" {...sharedProps} />
-            <ColorButton color="neuter" icon="neuter" title="Neuter" {...sharedProps} />
+            <ColorButton color="male" icon="font" title="Male" {...sharedProps} />
+            <ColorButton color="female" icon="font" title="Female" {...sharedProps} />
+            <ColorButton color="neuter" icon="font" title="Neuter" {...sharedProps} />
           </div>
           <div className="menu">
-            <ColorButton color="dative" icon="arrows-h" title="Dative" {...sharedProps} />
-            <ColorButton color="accusative" icon="times" title="Accusative" {...sharedProps} />
+            <ColorButton color="dative" icon="font" title="Dative" {...sharedProps} />
+            <ColorButton color="accusative" icon="font" title="Accusative" {...sharedProps} />
           </div>
         </ToolbarMenu>
         <ToolbarMenu type="character" icon="keyboard-o" title="Character Map" {...menuProps}>

--- a/src/plugins/Color.js
+++ b/src/plugins/Color.js
@@ -26,20 +26,12 @@ const colorStrategy = (value, color) => {
         change.addMark({ type: 'color', data: { color } }).focus()
       }
     }
-  } else if (value.isExpanded && color !== DEFAULT_COLOR) {
+  } else if (color !== DEFAULT_COLOR) {
     change.addMark({ type: 'color', data: { color } }).focus()
   }
 
   return change
 }
-
-export const ColorPlugin = ({ type }) => ({
-  renderMark (colorProps) {
-    const { attributes, children, mark } = colorProps
-    return (mark.type === type)
-      ? <span className={`color_${mark.data.get('color')}`} {...attributes}>{children}</span> : null
-  },
-})
 
 export const ColorButton = ({
   color, icon, title, value, onChange,

--- a/src/plugins/Mark.js
+++ b/src/plugins/Mark.js
@@ -8,11 +8,18 @@ const markStrategy = (change, mark) => change
   .toggleMark(mark)
   .focus()
 
+// Handling Color too...ugh
 export const MarkPlugin = ({ hotkeys }) => ({
   renderMark (markProps) {
     const { marks, attributes, children } = markProps
     if (marks.size > 0 && typeof (children) === 'string') {
-      const classNames = marks.map(mark => `mark_${mark.type}`).join(' ')
+      const classNames = marks.map(mark => {
+        if (mark.type === 'color') {
+          return `color_${mark.data.get('color')}`
+        }
+        return `mark_${mark.type}`
+      }).join(' ')
+
       return <span className={classNames} {...attributes}>{children}</span>
     }
     return null


### PR DESCRIPTION
Because of #4, the `MarkPlugin` now takes over rendering all marks. I think that's fine, and it should be extracted eventually to a separate file. Perhaps when we need another mark. Also changed all the font icons to "A"s per Inda's request.

![fix](https://user-images.githubusercontent.com/12610/33384153-83d7fcf0-d525-11e7-94c3-3a1aa51d8aae.gif)
