### PR TITLE
A few fixes based on some Curriculum feedback!

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,9 +40,9 @@ const plugins = [
   VoidPlugin({ type: 'underbar', tag: 'span', attributes: { className: 'underbar' } }),
   VoidPlugin({ type: 'underbar_l', tag: 'span', attributes: { className: 'underbar_l' } }),
   VoidPlugin({ type: 'underbar_xl', tag: 'span', attributes: { className: 'underbar_xl' } }),
+  SoftBreak({ shift: true }),
   EditListPlugin,
   EditTablePlugin,
-  SoftBreak({ shift: true }),
   TrailingBlock(),
 ]
 


### PR DESCRIPTION
- [x] Shift+Enter should put a newline inside of a table
- [ ] See if schema can disallow bold for headings
- [ ] Strip empty lines if possible