### PR TITLE
Rename external handler* fn's to on*, add setValue

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', event => {
   const clearLink = document.getElementById('clear')
   clearLink.onclick = () => {
     global.editor.clearStorage()
-    window.location.reload()
+    global.editor.setValue(initialValue)
   }
 })
 

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <div class="tips">
           Protip: Use ⌘+Return to jump out of a pattern.
           <br />
-          <a href="#" id="serialize">Serialize content as JSON.</a> - <a href="#" id="clear">Clear local storage.</a>
+          <a href="#" id="serialize">Serialize content as JSON.</a> - <a href="#" id="clear">Clear local storage and reset.</a>
         </div>
         <div class="tips" id="serializedContent"></div>
       </div>

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -10,8 +10,8 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch (error, info) {
     this.setState({ error })
-    if (this.props.handleError) {
-      this.props.handleError.call(error, info)
+    if (this.props.onError) {
+      this.props.onError.call(error, info)
     }
   }
 
@@ -29,7 +29,7 @@ class ErrorBoundary extends React.Component {
 }
 
 ErrorBoundary.propTypes = {
-  handleError: PropTypes.func,
+  onError: PropTypes.func,
   children: PropTypes.node,
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,8 +63,8 @@ class TopicEditor extends React.Component {
     placeholder: PropTypes.string,
     className: PropTypes.string,
     title: PropTypes.element,
-    handleError: PropTypes.func,
-    handleEditorChanged: PropTypes.func,
+    onError: PropTypes.func,
+    onEditorChanged: PropTypes.func,
   }
 
   static defaultProps = {
@@ -84,6 +84,15 @@ class TopicEditor extends React.Component {
   }
 
   /**
+   * Load a value into the editor, for example when clearing changes
+   *
+   * @param {object} value - parsed into a SlateJS {Value}
+   */
+  setValue (value) {
+    this.setState({ value: Value.fromJSON(value) })
+  }
+
+  /**
    * On change, save the new `value`, and hide the color menu
    *
    * @param {Change} change
@@ -97,8 +106,8 @@ class TopicEditor extends React.Component {
 
     if (value.document !== this.state.value.document) {
       localStorage.setItem(LocalStorageKey, jsonContent)
-      if (this.props.handleEditorChanged) {
-        this.props.handleEditorChanged.call(LocalStorageKey)
+      if (this.props.onEditorChanged) {
+        this.props.onEditorChanged.call(LocalStorageKey)
       }
     }
 
@@ -106,7 +115,7 @@ class TopicEditor extends React.Component {
       value,
       menus: {},
     })
-  };
+  }
 
   handleClickUndo = event => {
     event.preventDefault()
@@ -123,10 +132,10 @@ class TopicEditor extends React.Component {
   }
 
   render () {
-    const { title, handleError } = this.props
+    const { title, onError } = this.props
     const { mobileView } = this.state
     return (
-      <ErrorBoundary handleError={handleError}>
+      <ErrorBoundary onError={onError}>
         <div className={`chatterslate ${mobileView ? 'chatterslate_mobile' : ''}`}>
           {this.renderToolbar()}
           {title}


### PR DESCRIPTION
Address feedback from https://github.com/chatterbugapp/chatterslate/pull/16#discussion_r168902003

And provide a way to get around having to deal with using a `key` prop for a `<TopicEditor>` just to reset its contents.