### PR TITLE
Hotkey to switch speaker in conversation mode

### DIFF
--- a/src/components/TopicToolbar.js
+++ b/src/components/TopicToolbar.js
@@ -52,8 +52,8 @@ const renderInConversation = sharedProps => {
   return (
     <div>
       <small>Conversations</small>
-      <ListItemButton data={{ className: 'student' }} icon="user" title="Student" {...sharedProps} />
-      <ListItemButton data={{ className: 'tutor' }} icon="user" title="Tutor" {...sharedProps} />
+      <ListItemButton data={{ className: 'student', role: 'student' }} icon="user" title="Student" {...sharedProps} />
+      <ListItemButton data={{ className: 'tutor', role: 'tutor' }} icon="user" title="Tutor" {...sharedProps} />
     </div>
   )
 }

--- a/src/plugins/KeyPlugin.js
+++ b/src/plugins/KeyPlugin.js
@@ -1,6 +1,7 @@
 import { isKeyHotkey } from 'is-hotkey'
 import MarkStrategy from '../strategies/MarkStrategy'
 import ColorStrategy from '../strategies/ColorStrategy'
+import SpeakerStrategy from '../strategies/SpeakerStrategy'
 import TopicColors from '../TopicColors'
 
 const markHotkeys = Object.entries({

--- a/src/plugins/KeyPlugin.js
+++ b/src/plugins/KeyPlugin.js
@@ -14,6 +14,7 @@ const colorHotkeys = Object.entries(TopicColors)
   .map(([color, colorProps]) => [color, isKeyHotkey(colorProps.hotkey)])
 
 const lastColorHotkey = isKeyHotkey('mod+shift+x')
+const switchSpeakerHotkey = isKeyHotkey('mod+k')
 
 const KeyPlugin = () => ({
   onKeyDown (event, data, editor) {
@@ -32,6 +33,11 @@ const KeyPlugin = () => ({
     if (lastColorHotkey(event)) {
       event.preventDefault()
       return editor.onChange(ColorStrategy(editor.state.value))
+    }
+
+    if (switchSpeakerHotkey(event)) {
+      event.preventDefault()
+      return editor.onChange(SpeakerStrategy(editor.state.value))
     }
 
     return null

--- a/src/strategies/SpeakerStrategy.js
+++ b/src/strategies/SpeakerStrategy.js
@@ -1,0 +1,21 @@
+const DefaultSpeaker = 'student'
+
+/**
+ * Alternates a conversation list item between speaker and tutor.
+ */
+const SpeakerStrategy = (value) => {
+  const change = value.change()
+  const firstBlock = change.value.startBlock
+
+  if (firstBlock) {
+    const itemBlock = change.value.document.getClosestBlock(firstBlock.key)
+    if (itemBlock && itemBlock.type === 'list_item') {
+      const data = { className: itemBlock.hasClass('tutor') ? 'student' : 'tutor' }
+      return change.setNodeByKey(itemBlock.key, { data })
+    }
+  }
+
+  return change
+}
+
+export default SpeakerStrategy


### PR DESCRIPTION
I got this far, then realised to get the current value of speaker (as intended through the non-existent `hasClass` behaviour), the list item should have been storing either `tutor` or `student` as data values to begin with. 🤕 